### PR TITLE
Add ClipRocket Studio to Promotion and Marketing Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@
 
 - **[Canva](https://www.canva.com/)** - Create podcast cover art and promotional graphics.
 - **[Headliner](https://www.headliner.app/)** - Create audiograms and shareable video clips from your episodes.
+- **[ClipRocket Studio](https://cliprocketstudio.com)** - Hebrew-first AI clip generator that turns long-form video podcasts into vertical shorts for YouTube Shorts, TikTok, and Reels with burned-in Hebrew captions.
 - **[Buffer](https://buffer.com/)** - Schedule social media posts to promote your podcast.
 - **[Aweber](https://www.aweber.com/)** - An email marketing platform for engaging your audience.
 - **[Linktree](https://linktr.ee/)** - Share all your podcast links in one place.


### PR DESCRIPTION
## Thank you for your contribution!

### Checklist

- [x] My submission is useful and relevant to this list.
- [x] I've added a short description for the resource.
- [x] The link is not a duplicate.
- [x] The link is working and publicly accessible.
- [x] I've checked that the resource follows our quality and content standards.
- [x] I have not added a link to my own project if it's not notable or widely used.

### Description of the Change

Adds **ClipRocket Studio** (https://cliprocketstudio.com) to the **Promotion and Marketing Tools** section.

ClipRocket is a Hebrew-first AI tool that turns long-form video podcasts into vertical short clips for YouTube Shorts, TikTok, Instagram Reels, and Facebook Reels — auto-picks moments, burns in Hebrew captions, generates Hebrew titles.

It sits naturally next to Headliner in the same section (both produce shareable video clips from podcast episodes), but covers a gap that English-only tools like Headliner / OpusClip / Vizard don't address: Hebrew (RTL) captions and Hebrew title generation. Useful for the growing Hebrew-speaking podcaster audience.

### Additional Notes

- Live and publicly accessible.
- This submission was prepared with help from an AI coding assistant; the tool itself is built and operated by Dov.
